### PR TITLE
Fix index path for FastAPI server

### DIFF
--- a/server.py
+++ b/server.py
@@ -1,13 +1,15 @@
 # server.py
 from fastapi import FastAPI, HTTPException
 from fastapi.responses import FileResponse
+from pathlib import Path
 from pydantic import BaseModel
 from app import ingest_faqs, query_faq  # import your refactored functions
 
 app = FastAPI()
 @app.get("/", include_in_schema=False)
 async def read_index():
-    return FileResponse("index.html")
+    index_path = Path(__file__).resolve().parent / "index.html"
+    return FileResponse(index_path)
 client = None
 
 class QueryReq(BaseModel):


### PR DESCRIPTION
## Summary
- make FastAPI server serve `index.html` relative to file path

## Testing
- `python -m py_compile app.py server.py`
