### PR TITLE
Add tests for FastAPI endpoints

### DIFF
--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,0 +1,26 @@
+from fastapi.testclient import TestClient
+from unittest.mock import patch
+import server
+
+
+def _create_client():
+    """Utility to create TestClient while patching startup."""
+    return TestClient(server.app)
+
+
+def test_health():
+    with patch("server.ingest_faqs", return_value="dummy_client"):
+        with _create_client() as client:
+            res = client.get("/health")
+            assert res.status_code == 200
+            assert res.json() == {"status": "ok"}
+
+
+def test_query_endpoint():
+    with patch("server.ingest_faqs", return_value="dummy_client"):
+        with patch("server.query_faq", return_value={"question": "stored q", "answer": "stored a"}) as mock_query:
+            with _create_client() as client:
+                res = client.post("/query", json={"question": "user q"})
+                assert res.status_code == 200
+                assert res.json() == {"question": "stored q", "answer": "stored a"}
+                mock_query.assert_called_with("user q", "dummy_client")


### PR DESCRIPTION
## Summary
- add test cases covering `/health` and `/query` endpoints

## Testing
- `pytest -q` *(fails: command not found)*
- `pip install pytest --quiet` *(fails: could not find version)*