### PR TITLE
Add env template and dev instructions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# Copy to .env and fill in your secrets
+DATABASE_URL=tidb://<user>:<pass>@<host>:<port>/test
+AWS_REGION=us-east-1
+FAQ_FILE=faqs.json

--- a/README.md
+++ b/README.md
@@ -35,8 +35,16 @@ pip install -r requirements.txt
 
 ### Required Environment Variables
 
+Create a `.env` file based on the provided template and fill in your own values:
+
+```bash
+cp .env.example .env
+# edit .env with your secrets
+```
+
 - `DATABASE_URL` – TiDB connection string
 - `AWS_REGION` – AWS region for Bedrock (defaults to `us-east-1`)
+- `FAQ_FILE` – path to the FAQ JSON file (defaults to `faqs.json`)
 ---
 
 ## 🌐 Web Interface
@@ -50,12 +58,29 @@ Prefer a web page over a terminal? Here’s how:
 
 2. **Check that `server.py` and `index.html` live in your project folder.**
 
-3. **Run the server**  
+3. **Start the dev server with a progress bar**
+   ```bash
+   python run_with_bar.py
+   ```
+
+   *(This script runs Uvicorn and waits for the `/health` endpoint to respond before handing over the logs.)*
+4. **Run the server manually (alternative)**
    ```bash
    uvicorn server:app --reload --host 0.0.0.0 --port 8000
    ```
 
-4. **Open your browser** to <http://localhost:8000> and start asking questions.
+5. **Open your browser** to <http://localhost:8000> and start asking questions.
 
-5. The included `index.html` uses React (loaded via CDN) so you get a modern UI
-   with a dark/light toggle and a growing history of your queries and results.
+6. The included `index.html` uses React (loaded via CDN) so you get a modern UI
+    with a dark/light toggle and a growing history of your queries and results.
+
+---
+
+## Running Tests
+
+Install development dependencies and run `pytest`:
+
+```bash
+pip install -r requirements.txt
+pytest
+```


### PR DESCRIPTION
## Summary
- document a simple `.env` template
- update README with environment setup, dev server instructions and test steps

## Testing
- `pip install -r requirements.txt` *(fails: Could not connect to proxy)*
- `pytest -q` *(fails: command not found)*